### PR TITLE
Sort names lexicographically, except numbers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,10 +655,22 @@ dependencies = [
  "clap",
  "crossterm",
  "indexmap",
+ "num-bigint",
  "ratatui",
  "serde",
  "serde_derive",
  "serde_json",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -668,6 +680,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
 dependencies = [
  "bytemuck",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
  "num-traits",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 authors = ["David Holtz <github.com/drbh>"]
 
 [dependencies]
+num-bigint = "0.4"
 candle-onnx = "0.3.1"
 clap = { version = "4.4.8", features = ["derive"] }
 crossterm = "0.27.0"


### PR DESCRIPTION
This is a proposal for a parameter ordering. It results in names that are lexicographically sorted, except numbers are sorted numerically when two names share the same prefix. So the result is:

layer.1.bar
layer.1.foo
layer.2.bar
layer.2.foo
layer.10.bar
layer.10.foo

Rather than:

layer.1.bar
layer.1.foo
layer.10.bar
layer.10.foo
layer.2.bar
layer.2.foo

<img width="1479" alt="Screenshot 2024-06-05 at 21 09 07" src="https://github.com/drbh/nnli/assets/49398/3885d191-99ac-46aa-ad72-57987b12790c">

I think this is what one would commonly want, layers ordered by increasing number and within layers an alphabetic order to make it easier to spot a parameter.